### PR TITLE
Introduce output helpers

### DIFF
--- a/src/backends/foundry.rs
+++ b/src/backends/foundry.rs
@@ -159,8 +159,8 @@ mod tests {
         // This test will pass if Foundry is installed, otherwise it will show
         // the helpful error message
         match ensure_available() {
-            Ok(_) => println!("✓ Foundry (forge and cast) is available"),
-            Err(e) => println!("✗ Foundry not available: {}", e),
+            Ok(_) => println!("{}", crate::util::success("Foundry (forge and cast) is available")),
+            Err(e) => println!("{}", crate::util::error(&format!("Foundry not available: {}", e))),
         }
     }
 }

--- a/src/backends/garaga.rs
+++ b/src/backends/garaga.rs
@@ -82,8 +82,8 @@ mod tests {
         // This test will pass if garaga is installed, otherwise it will show
         // the helpful error message
         match ensure_available() {
-            Ok(_) => println!("✓ garaga is available"),
-            Err(e) => println!("✗ garaga not available: {}", e),
+            Ok(_) => println!("{}", crate::util::success("garaga is available")),
+            Err(e) => println!("{}", crate::util::error(&format!("garaga not available: {}", e))),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,9 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
+pub mod output;
+pub use output::{colorize, colors, error, info, path, print_banner, success, warning};
+
 /// Backend flavour for artifact generation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Flavour {
@@ -461,97 +464,6 @@ pub fn create_smart_error(message: &str, suggestions: &[&str]) -> color_eyre::ey
     color_eyre::eyre::eyre!(error_msg)
 }
 
-/// ANSI color codes for terminal output
-pub mod colors {
-    pub const RESET: &str = "\x1b[0m";
-    pub const BOLD: &str = "\x1b[1m";
-    pub const GREEN: &str = "\x1b[32m";
-    pub const RED: &str = "\x1b[31m";
-    pub const YELLOW: &str = "\x1b[33m";
-    pub const BLUE: &str = "\x1b[34m";
-    pub const CYAN: &str = "\x1b[36m";
-    pub const GRAY: &str = "\x1b[90m";
-    pub const BRIGHT_GREEN: &str = "\x1b[92m";
-    pub const BRIGHT_BLUE: &str = "\x1b[94m";
-    pub const BRIGHT_CYAN: &str = "\x1b[96m";
-}
-
-/// Format text with color
-pub fn colorize(text: &str, color: &str) -> String {
-    if std::env::var("NO_COLOR").is_ok() || !atty::is(atty::Stream::Stdout) {
-        text.to_string()
-    } else {
-        format!("{}{}{}", color, text, colors::RESET)
-    }
-}
-
-/// Create success message with green color
-pub fn success(text: &str) -> String {
-    colorize(&format!("✅ {}", text), colors::BRIGHT_GREEN)
-}
-
-/// Create error message with red color
-pub fn error(text: &str) -> String {
-    colorize(&format!("❌ {}", text), colors::RED)
-}
-
-/// Create warning message with yellow color
-pub fn warning(text: &str) -> String {
-    colorize(&format!("⚠️ {}", text), colors::YELLOW)
-}
-
-/// Create info message with blue color
-pub fn info(text: &str) -> String {
-    colorize(&format!("ℹ️ {}", text), colors::BRIGHT_BLUE)
-}
-
-/// Create path text with cyan color
-pub fn path(text: &str) -> String {
-    colorize(text, colors::BRIGHT_CYAN)
-}
-
-/// ASCII art banners for different operations
-pub fn print_banner(operation: &str) {
-    let banner = match operation {
-        "build" => {
-            "┌─────────────────────────────────┐\n\
-             │ 🔨 BUILDING NOIR CIRCUIT       │\n\
-             └─────────────────────────────────┘"
-        }
-        "prove" => {
-            "┌─────────────────────────────────┐\n\
-             │ 🔐 GENERATING PROOF & VK        │\n\
-             └─────────────────────────────────┘"
-        }
-        "verify" => {
-            "┌─────────────────────────────────┐\n\
-             │ ✅ VERIFYING PROOF              │\n\
-             └─────────────────────────────────┘"
-        }
-        "solidity" => {
-            "┌─────────────────────────────────┐\n\
-             │ 📄 GENERATING SOLIDITY VERIFIER │\n\
-             └─────────────────────────────────┘"
-        }
-        "clean" => {
-            "┌─────────────────────────────────┐\n\
-             │ 🧹 CLEANING BUILD ARTIFACTS    │\n\
-             └─────────────────────────────────┘"
-        }
-        "check" => {
-            "┌─────────────────────────────────┐\n\
-             │ 🔍 CHECKING CIRCUIT SYNTAX      │\n\
-             └─────────────────────────────────┘"
-        }
-        _ => {
-            "┌─────────────────────────────────┐\n\
-             │ 🚀 RUNNING BARGO OPERATION      │\n\
-             └─────────────────────────────────┘"
-        }
-    };
-
-    println!("{}", colorize(banner, colors::BRIGHT_BLUE));
-}
 
 /// Print operation summary with colored output
 pub struct OperationSummary {

--- a/src/util/output.rs
+++ b/src/util/output.rs
@@ -1,0 +1,94 @@
+// Utility functions for colored CLI output
+// Extracted from util.rs
+
+/// ANSI color codes for terminal output
+pub mod colors {
+    pub const RESET: &str = "\x1b[0m";
+    pub const BOLD: &str = "\x1b[1m";
+    pub const GREEN: &str = "\x1b[32m";
+    pub const RED: &str = "\x1b[31m";
+    pub const YELLOW: &str = "\x1b[33m";
+    pub const BLUE: &str = "\x1b[34m";
+    pub const CYAN: &str = "\x1b[36m";
+    pub const GRAY: &str = "\x1b[90m";
+    pub const BRIGHT_GREEN: &str = "\x1b[92m";
+    pub const BRIGHT_BLUE: &str = "\x1b[94m";
+    pub const BRIGHT_CYAN: &str = "\x1b[96m";
+}
+
+/// Format text with color
+pub fn colorize(text: &str, color: &str) -> String {
+    if std::env::var("NO_COLOR").is_ok() || !atty::is(atty::Stream::Stdout) {
+        text.to_string()
+    } else {
+        format!("{}{}{}", color, text, colors::RESET)
+    }
+}
+
+/// Create success message with green color
+pub fn success(text: &str) -> String {
+    colorize(&format!("✅ {}", text), colors::BRIGHT_GREEN)
+}
+
+/// Create error message with red color
+pub fn error(text: &str) -> String {
+    colorize(&format!("❌ {}", text), colors::RED)
+}
+
+/// Create warning message with yellow color
+pub fn warning(text: &str) -> String {
+    colorize(&format!("⚠️ {}", text), colors::YELLOW)
+}
+
+/// Create info message with blue color
+pub fn info(text: &str) -> String {
+    colorize(&format!("ℹ️ {}", text), colors::BRIGHT_BLUE)
+}
+
+/// Create path text with cyan color
+pub fn path(text: &str) -> String {
+    colorize(text, colors::BRIGHT_CYAN)
+}
+
+/// ASCII art banners for different operations
+pub fn print_banner(operation: &str) {
+    let banner = match operation {
+        "build" => {
+            "┌─────────────────────────────────┐\n\
+             │ 🔨 BUILDING NOIR CIRCUIT       │\n\
+             └─────────────────────────────────┘"
+        }
+        "prove" => {
+            "┌─────────────────────────────────┐\n\
+             │ 🔐 GENERATING PROOF & VK        │\n\
+             └─────────────────────────────────┘"
+        }
+        "verify" => {
+            "┌─────────────────────────────────┐\n\
+             │ ✅ VERIFYING PROOF              │\n\
+             └─────────────────────────────────┘"
+        }
+        "solidity" => {
+            "┌─────────────────────────────────┐\n\
+             │ 📄 GENERATING SOLIDITY VERIFIER │\n\
+             └─────────────────────────────────┘"
+        }
+        "clean" => {
+            "┌─────────────────────────────────┐\n\
+             │ 🧹 CLEANING BUILD ARTIFACTS    │\n\
+             └─────────────────────────────────┘"
+        }
+        "check" => {
+            "┌─────────────────────────────────┐\n\
+             │ 🔍 CHECKING CIRCUIT SYNTAX      │\n\
+             └─────────────────────────────────┘"
+        }
+        _ => {
+            "┌────────────────────────────────┐\n\
+             │ 🚀 RUNNING BARGO OPERATION      │\n\
+             └─────────────────────────────────┘"
+        }
+    };
+
+    println!("{}", colorize(banner, colors::BRIGHT_BLUE));
+}


### PR DESCRIPTION
## Summary
- add `util::output` module with colorized printing helpers
- re-export output helpers from `util`
- update Garaga and Foundry tests to use helpers

## Testing
- `cargo test --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68598884fc9083299a89f281c30c0593