### PR TITLE
Add inline tests for backend utilities

### DIFF
--- a/src/backends/bb.rs
+++ b/src/backends/bb.rs
@@ -33,3 +33,14 @@ pub fn run(args: &[&str]) -> Result<()> {
     debug!("bb command completed successfully");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_version() {
+        // Call bb --version if available; just ensure function doesn't panic
+        let _ = run(&["--version"]);
+    }
+}

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -40,3 +40,20 @@ pub fn spawn_cmd(cmd_name: &str, args: &[&str]) -> Result<()> {
     debug!("{} command completed successfully", cmd_name);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_spawn_cmd_success() {
+        // Should succeed running a simple echo command
+        assert!(spawn_cmd("echo", &["hello"]).is_ok());
+    }
+
+    #[test]
+    fn test_spawn_cmd_failure() {
+        // The `false` command exits with a non-zero status
+        assert!(spawn_cmd("false", &[]).is_err());
+    }
+}

--- a/src/backends/nargo.rs
+++ b/src/backends/nargo.rs
@@ -33,3 +33,14 @@ pub fn run(args: &[&str]) -> Result<()> {
     debug!("nargo command completed successfully");
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_help() {
+        // Run "nargo --help" if available; ensures invocation path works
+        let _ = run(&["--help"]);
+    }
+}


### PR DESCRIPTION
## Summary
- add local tests for backend helpers
- ensure each backend utility has a `#[cfg(test)] mod tests` section

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68598888dd548329b00c56401e6feb83