### PR TITLE
Refactor CLI into modular structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +102,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -106,8 +128,10 @@ dependencies = [
 name = "bargo"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "bargo-core",
  "color-eyre",
+ "predicates",
  "tempfile",
 ]
 
@@ -134,6 +158,17 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -215,6 +250,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +304,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "getrandom"
@@ -395,6 +451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +464,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -442,6 +513,36 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -636,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +880,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ color-eyre = "0.6.5"
 
 [dev-dependencies]
 tempfile = "3.8"
+assert_cmd = "2"
+predicates = "3"

--- a/crates/bargo-core/src/cli.rs
+++ b/crates/bargo-core/src/cli.rs
@@ -1,0 +1,159 @@
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// A developer-friendly CLI wrapper for Noir ZK development
+#[derive(Parser)]
+#[command(
+    name = "bargo",
+    about = "A developer-friendly CLI wrapper for Noir ZK development",
+    long_about = "bargo consolidates nargo and bb workflows into a single, opinionated tool that 'just works' in a standard Noir workspace.",
+    version
+)]
+pub struct Cli {
+    /// Enable verbose logging (shows underlying commands)
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
+    /// Print commands without executing them
+    #[arg(long, global = true)]
+    pub dry_run: bool,
+
+    /// Override package name (auto-detected from Nargo.toml)
+    #[arg(long, global = true)]
+    pub pkg: Option<String>,
+
+    /// Minimize output
+    #[arg(short, long, global = true)]
+    pub quiet: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Check circuit syntax and dependencies
+    #[command(about = "Run nargo check to validate circuit syntax and dependencies")]
+    Check,
+
+    /// Build circuit (compile + execute to generate bytecode and witness)
+    #[command(about = "Run nargo execute to generate bytecode and witness files")]
+    Build,
+
+    /// Clean build artifacts
+    #[command(about = "Remove target directory and all build artifacts")]
+    Clean {
+        /// Backend to clean (defaults to all)
+        #[arg(long, value_enum)]
+        backend: Option<Backend>,
+    },
+
+    /// Clean and rebuild (equivalent to clean + build)
+    #[command(about = "Remove target directory and rebuild from scratch")]
+    Rebuild {
+        /// Backend to clean (defaults to all)
+        #[arg(long, value_enum)]
+        backend: Option<Backend>,
+    },
+
+    /// Cairo/Starknet operations
+    #[command(about = "Generate Cairo verifiers and interact with Starknet")]
+    Cairo {
+        #[command(subcommand)]
+        command: CairoCommands,
+    },
+
+    /// EVM/Foundry operations
+    #[command(about = "Generate Solidity verifiers and interact with EVM networks")]
+    Evm {
+        #[command(subcommand)]
+        command: EvmCommands,
+    },
+
+    /// Check system dependencies
+    #[command(about = "Verify that all required tools are installed and available")]
+    Doctor,
+}
+
+#[derive(Subcommand)]
+pub enum CairoCommands {
+    /// Generate Cairo verifier contract
+    #[command(about = "Generate Cairo verifier contract for Starknet deployment")]
+    Gen,
+
+    /// Generate Starknet oracle proof
+    #[command(about = "Generate proof using bb with Starknet oracle hash")]
+    Prove,
+
+    /// Verify Starknet oracle proof
+    #[command(about = "Verify proof generated with Starknet oracle hash")]
+    Verify,
+
+    /// Generate calldata for proof verification
+    #[command(about = "Generate calldata JSON for latest proof")]
+    Calldata,
+
+    /// Declare verifier contract on Starknet
+    #[command(about = "Declare verifier contract on Starknet")]
+    Declare {
+        /// Network to declare on (sepolia or mainnet)
+        #[arg(long, default_value = "sepolia")]
+        network: String,
+    },
+
+    /// Deploy declared verifier contract
+    #[command(about = "Deploy declared verifier contract")]
+    Deploy {
+        /// Class hash of the declared contract
+        #[arg(long)]
+        class_hash: Option<String>,
+    },
+
+    /// Verify proof on-chain
+    #[command(about = "Verify proof on Starknet using deployed verifier")]
+    VerifyOnchain {
+        /// Address of deployed verifier contract
+        #[arg(short = 'a', long)]
+        address: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum EvmCommands {
+    /// Generate Solidity verifier contract and Foundry project
+    #[command(about = "Generate Solidity verifier contract with complete Foundry project setup")]
+    Gen,
+
+    /// Generate Keccak oracle proof
+    #[command(about = "Generate proof using bb with Keccak oracle hash")]
+    Prove,
+
+    /// Verify Keccak oracle proof
+    #[command(about = "Verify proof generated with Keccak oracle hash")]
+    Verify,
+
+    /// Deploy verifier contract to EVM network
+    #[command(about = "Deploy verifier contract using Foundry")]
+    Deploy {
+        /// Network to deploy to (mainnet or sepolia)
+        #[arg(long, default_value = "sepolia")]
+        network: String,
+    },
+
+    /// Generate calldata for proof verification
+    #[command(about = "Generate calldata for proof verification using cast")]
+    Calldata,
+
+    /// Verify proof on-chain
+    #[command(about = "Verify proof on EVM network using deployed verifier")]
+    VerifyOnchain,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Backend {
+    /// Barretenberg backend (EVM/Solidity)
+    Bb,
+    /// Starknet backend (Cairo)
+    Starknet,
+    /// All backends
+    All,
+}

--- a/crates/bargo-core/src/commands/build.rs
+++ b/crates/bargo-core/src/commands/build.rs
@@ -3,45 +3,51 @@ use tracing::info;
 
 use crate::{
     backends,
-    util::{self, Flavour, Timer, format_operation_result, success},
-    Cli,
+    commands::build_nargo_args,
+    config::Config,
+    util::{self, format_operation_result, success, Flavour, Timer},
 };
 
 /// Determine whether a rebuild is needed based on source timestamps
-pub fn should_rebuild(pkg: &str, cli: &Cli) -> Result<bool> {
-    if cli.dry_run { return Ok(true); }
+pub fn should_rebuild(pkg: &str, cfg: &Config) -> Result<bool> {
+    if cfg.dry_run { return Ok(true); }
     util::needs_rebuild(pkg)
 }
 
-/// Run `nargo execute` with the provided arguments
+/// Run `nargo execute` with the provided arguments.
+///
+/// The slice is typically produced by [`build_nargo_args`].
 pub fn run_nargo_execute(args: &[&str]) -> Result<()> {
     backends::nargo::run(args)
 }
 
 /// Execute the build workflow
-pub fn run(cli: &Cli) -> Result<()> {
-    let pkg_name = util::get_package_name(cli.pkg.as_ref())?;
+pub fn run(cfg: &Config) -> Result<()> {
+    let args = build_nargo_args(cfg, &["execute"])?;
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    if cfg.verbose {
+        info!("Running: nargo {}", args.join(" "));
+    }
 
-    if !should_rebuild(&pkg_name, cli)? {
-        if !cli.quiet {
+    if cfg.dry_run {
+        println!("Would run: nargo {}", args.join(" "));
+        return Ok(());
+    }
+
+    let pkg_name = util::get_package_name(cfg.pkg.as_ref())?;
+
+    if !should_rebuild(&pkg_name, cfg)? {
+        if !cfg.quiet {
             println!("{}", success("Build is up to date"));
         }
         return Ok(());
     }
 
-    let args = ["execute"];
-    if cli.verbose { info!("Running: nargo execute {:?}", args); }
-
-    if cli.dry_run {
-        println!("Would run: nargo execute {}", args.join(" "));
-        return Ok(());
-    }
-
     let timer = Timer::start();
-    run_nargo_execute(&args)?;
+    run_nargo_execute(&arg_refs)?;
 
     util::organize_build_artifacts(&pkg_name, Flavour::Bb)?;
-    if !cli.quiet {
+    if !cfg.quiet {
         let bytecode_path = util::get_bytecode_path(&pkg_name, Flavour::Bb);
         let witness_path = util::get_witness_path(&pkg_name, Flavour::Bb);
         println!(

--- a/crates/bargo-core/src/commands/check.rs
+++ b/crates/bargo-core/src/commands/check.rs
@@ -1,0 +1,20 @@
+use color_eyre::Result;
+use tracing::info;
+
+use crate::{backends, commands::build_nargo_args, config::Config};
+
+pub fn run(cfg: &Config) -> Result<()> {
+    let args = build_nargo_args(cfg, &["check"])?;
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    if cfg.verbose {
+        info!("Running: nargo {}", args.join(" "));
+    }
+
+    if cfg.dry_run {
+        println!("Would run: nargo {}", args.join(" "));
+        return Ok(());
+    }
+
+    backends::nargo::run(&arg_refs)
+}

--- a/crates/bargo-core/src/commands/clean.rs
+++ b/crates/bargo-core/src/commands/clean.rs
@@ -1,0 +1,60 @@
+use color_eyre::Result;
+use tracing::info;
+
+use crate::{config::Config, cli::Backend, util::{info as info_msg, success}};
+
+pub fn run(cfg: &Config, backend: Backend) -> Result<()> {
+    if cfg.verbose {
+        info!("Cleaning artifacts for backend: {:?}", backend);
+    }
+
+    match backend {
+        Backend::All => {
+            if cfg.dry_run {
+                println!("Would run: rm -rf target/");
+                return Ok(());
+            }
+
+            if std::path::Path::new("target").exists() {
+                std::fs::remove_dir_all("target")?;
+                if !cfg.quiet {
+                    println!("{}", success("Removed target/"));
+                }
+            } else if !cfg.quiet {
+                println!("{}", info_msg("target/ already clean"));
+            }
+        }
+        Backend::Bb => {
+            if cfg.dry_run {
+                println!("Would run: rm -rf target/bb/");
+                return Ok(());
+            }
+
+            if std::path::Path::new("target/bb").exists() {
+                std::fs::remove_dir_all("target/bb")?;
+                if !cfg.quiet {
+                    println!("{}", success("Removed target/bb/"));
+                }
+            } else if !cfg.quiet {
+                println!("{}", info_msg("target/bb/ already clean"));
+            }
+        }
+        Backend::Starknet => {
+            if cfg.dry_run {
+                println!("Would run: rm -rf target/starknet/");
+                return Ok(());
+            }
+
+            if std::path::Path::new("target/starknet").exists() {
+                std::fs::remove_dir_all("target/starknet")?;
+                if !cfg.quiet {
+                    println!("{}", success("Removed target/starknet/"));
+                }
+            } else if !cfg.quiet {
+                println!("{}", info_msg("target/starknet/ already clean"));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/bargo-core/src/commands/common.rs
+++ b/crates/bargo-core/src/commands/common.rs
@@ -1,0 +1,15 @@
+use color_eyre::Result;
+
+use crate::config::Config;
+
+/// Build argument list for nargo commands based on global config
+pub fn build_nargo_args(cfg: &Config, base_args: &[&str]) -> Result<Vec<String>> {
+    let mut args = base_args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+    if let Some(pkg) = &cfg.pkg {
+        args.push("--package".to_string());
+        args.push(pkg.clone());
+    }
+
+    Ok(args)
+}

--- a/crates/bargo-core/src/commands/doctor.rs
+++ b/crates/bargo-core/src/commands/doctor.rs
@@ -1,0 +1,107 @@
+use color_eyre::Result;
+
+use crate::config::Config;
+
+pub fn run(cfg: &Config) -> Result<()> {
+    if !cfg.quiet {
+        println!("🔍 Checking system dependencies...\n");
+    }
+
+    let mut all_good = true;
+
+    match which::which("nargo") {
+        Ok(path) => {
+            if !cfg.quiet {
+                println!("✅ nargo: {}", path.display());
+            }
+        }
+        Err(_) => {
+            if !cfg.quiet {
+                println!("❌ nargo: not found");
+                println!(
+                    "   Install from: https://noir-lang.org/docs/getting_started/installation/"
+                );
+            }
+            all_good = false;
+        }
+    }
+
+    match which::which("bb") {
+        Ok(path) => {
+            if !cfg.quiet {
+                println!("✅ bb: {}", path.display());
+            }
+        }
+        Err(_) => {
+            if !cfg.quiet {
+                println!("❌ bb: not found");
+                println!("   Install from: https://github.com/AztecProtocol/aztec-packages");
+            }
+            all_good = false;
+        }
+    }
+
+    match which::which("garaga") {
+        Ok(path) => {
+            if !cfg.quiet {
+                println!("✅ garaga: {}", path.display());
+            }
+        }
+        Err(_) => {
+            if !cfg.quiet {
+                println!("⚠️  garaga: not found (optional - needed for Cairo features)");
+                println!("   Install with: pipx install garaga");
+                println!("   Requires Python 3.10+");
+            }
+        }
+    }
+
+    match which::which("forge") {
+        Ok(path) => {
+            if !cfg.quiet {
+                println!("✅ forge: {}", path.display());
+            }
+        }
+        Err(_) => {
+            if !cfg.quiet {
+                println!("⚠️  forge: not found (optional - needed for EVM features)");
+                println!("   Install with: curl -L https://foundry.paradigm.xyz | bash");
+                println!("   Then run: foundryup");
+            }
+        }
+    }
+
+    match which::which("cast") {
+        Ok(path) => {
+            if !cfg.quiet {
+                println!("✅ cast: {}", path.display());
+            }
+        }
+        Err(_) => {
+            if !cfg.quiet {
+                println!("⚠️  cast: not found (optional - needed for EVM features)");
+                println!("   Install with: curl -L https://foundry.paradigm.xyz | bash");
+                println!("   Then run: foundryup");
+            }
+        }
+    }
+
+    if !cfg.quiet {
+        println!();
+        if all_good {
+            println!("🎉 All required dependencies are available!");
+            println!("   You can use all bargo features.");
+        } else {
+            println!("🚨 Some required dependencies are missing.");
+            println!("   Core features require: nargo + bb");
+            println!("   EVM deployment features also require: forge + cast");
+            println!("   Cairo features also require: garaga");
+        }
+    }
+
+    if !all_good {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/crates/bargo-core/src/commands/mod.rs
+++ b/crates/bargo-core/src/commands/mod.rs
@@ -1,5 +1,11 @@
 pub mod build;
-
+pub mod cairo;
 pub mod evm;
 
-pub mod cairo;
+pub mod check;
+pub mod clean;
+pub mod rebuild;
+pub mod doctor;
+pub mod common;
+
+pub use common::build_nargo_args;

--- a/crates/bargo-core/src/commands/rebuild.rs
+++ b/crates/bargo-core/src/commands/rebuild.rs
@@ -1,0 +1,99 @@
+use color_eyre::Result;
+use tracing::info;
+
+use crate::{
+    backends,
+    cli::Backend,
+    config::Config,
+    commands::build_nargo_args,
+    util::{self, Flavour, OperationSummary, Timer, format_operation_result, path, success},
+};
+
+use super::clean;
+
+pub fn run(cfg: &Config, backend: Backend) -> Result<()> {
+    let mut summary = OperationSummary::new();
+
+    // Step 1: Clean
+    if cfg.verbose {
+        info!("Step 1/2: Cleaning artifacts for backend: {:?}", backend);
+    }
+
+    if !cfg.quiet {
+        println!("🧹 Cleaning build artifacts...");
+    }
+
+    clean::run(cfg, backend)?;
+    if backend != Backend::Starknet {
+        summary.add_operation("Build artifacts cleaned");
+    }
+
+    // Step 2: Build
+    if cfg.verbose {
+        info!("Step 2/2: Building from scratch");
+    }
+
+    if !cfg.quiet {
+        println!("\n🔨 Building circuit...");
+    }
+
+    let pkg_name =
+        util::get_package_name(cfg.pkg.as_ref()).map_err(util::enhance_error_with_suggestions)?;
+    let args = build_nargo_args(cfg, &["execute"])?;
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    if cfg.verbose {
+        info!("Running: nargo {}", args.join(" "));
+    }
+
+    if cfg.dry_run {
+        println!("Would run: nargo {}", args.join(" "));
+        return Ok(());
+    }
+
+    let timer = Timer::start();
+    let result = backends::nargo::run(&arg_refs);
+
+    match result {
+        Ok(()) => {
+            util::organize_build_artifacts(&pkg_name, Flavour::Bb)?;
+
+            if !cfg.quiet {
+                let bytecode_path = util::get_bytecode_path(&pkg_name, Flavour::Bb);
+                let witness_path = util::get_witness_path(&pkg_name, Flavour::Bb);
+
+                println!(
+                    "{}",
+                    success(&format_operation_result(
+                        "Bytecode generated",
+                        &bytecode_path,
+                        &timer
+                    ))
+                );
+
+                let witness_timer = Timer::start();
+                println!(
+                    "{}",
+                    success(&format_operation_result(
+                        "Witness generated",
+                        &witness_path,
+                        &witness_timer
+                    ))
+                );
+
+                summary.add_operation(&format!("Circuit rebuilt for {}", path(&pkg_name)));
+                summary.add_operation(&format!(
+                    "Bytecode generated ({})",
+                    util::format_file_size(&bytecode_path)
+                ));
+                summary.add_operation(&format!(
+                    "Witness generated ({})",
+                    util::format_file_size(&witness_path)
+                ));
+                summary.print();
+            }
+            Ok(())
+        }
+        Err(e) => Err(util::enhance_error_with_suggestions(e)),
+    }
+}

--- a/crates/bargo-core/src/config.rs
+++ b/crates/bargo-core/src/config.rs
@@ -1,0 +1,20 @@
+use crate::cli::Cli;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub verbose: bool,
+    pub dry_run: bool,
+    pub pkg: Option<String>,
+    pub quiet: bool,
+}
+
+impl From<&Cli> for Config {
+    fn from(cli: &Cli) -> Self {
+        Self {
+            verbose: cli.verbose,
+            dry_run: cli.dry_run,
+            pkg: cli.pkg.clone(),
+            quiet: cli.quiet,
+        }
+    }
+}

--- a/crates/bargo-core/src/lib.rs
+++ b/crates/bargo-core/src/lib.rs
@@ -1,184 +1,22 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::Parser;
 use color_eyre::Result;
 use tracing::{info, warn};
 
 mod backends;
-mod commands;
 mod util;
 
-use util::{
-    Flavour, OperationSummary, Timer, enhance_error_with_suggestions, format_operation_result,
-    info, path, print_banner, success,
-};
+pub mod cli;
+pub mod commands;
+pub mod config;
 
-/// A developer-friendly CLI wrapper for Noir ZK development
-#[derive(Parser)]
-#[command(
-    name = "bargo",
-    about = "A developer-friendly CLI wrapper for Noir ZK development",
-    long_about = "bargo consolidates nargo and bb workflows into a single, opinionated tool that 'just works' in a standard Noir workspace.",
-    version
-)]
-struct Cli {
-    /// Enable verbose logging (shows underlying commands)
-    #[arg(short, long, global = true)]
-    verbose: bool,
-
-    /// Print commands without executing them
-    #[arg(long, global = true)]
-    dry_run: bool,
-
-    /// Override package name (auto-detected from Nargo.toml)
-    #[arg(long, global = true)]
-    pkg: Option<String>,
-
-    /// Minimize output
-    #[arg(short, long, global = true)]
-    quiet: bool,
-
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Check circuit syntax and dependencies
-    #[command(about = "Run nargo check to validate circuit syntax and dependencies")]
-    Check,
-
-    /// Build circuit (compile + execute to generate bytecode and witness)
-    #[command(about = "Run nargo execute to generate bytecode and witness files")]
-    Build,
-
-    /// Clean build artifacts
-    #[command(about = "Remove target directory and all build artifacts")]
-    Clean {
-        /// Backend to clean (defaults to all)
-        #[arg(long, value_enum)]
-        backend: Option<Backend>,
-    },
-
-    /// Clean and rebuild (equivalent to clean + build)
-    #[command(about = "Remove target directory and rebuild from scratch")]
-    Rebuild {
-        /// Backend to clean (defaults to all)
-        #[arg(long, value_enum)]
-        backend: Option<Backend>,
-    },
-
-    /// Cairo/Starknet operations
-    #[command(about = "Generate Cairo verifiers and interact with Starknet")]
-    Cairo {
-        #[command(subcommand)]
-        command: CairoCommands,
-    },
-
-    /// EVM/Foundry operations
-    #[command(about = "Generate Solidity verifiers and interact with EVM networks")]
-    Evm {
-        #[command(subcommand)]
-        command: EvmCommands,
-    },
-
-    /// Check system dependencies
-    #[command(about = "Verify that all required tools are installed and available")]
-    Doctor,
-}
-
-#[derive(Subcommand)]
-enum CairoCommands {
-    /// Generate Cairo verifier contract
-    #[command(about = "Generate Cairo verifier contract for Starknet deployment")]
-    Gen,
-
-    /// Generate Starknet oracle proof
-    #[command(about = "Generate proof using bb with Starknet oracle hash")]
-    Prove,
-
-    /// Verify Starknet oracle proof
-    #[command(about = "Verify proof generated with Starknet oracle hash")]
-    Verify,
-
-    /// Generate calldata for proof verification
-    #[command(about = "Generate calldata JSON for latest proof")]
-    Calldata,
-
-    /// Declare verifier contract on Starknet
-    #[command(about = "Declare verifier contract on Starknet")]
-    Declare {
-        /// Network to declare on (sepolia or mainnet)
-        #[arg(long, default_value = "sepolia")]
-        network: String,
-    },
-
-    /// Deploy declared verifier contract
-    #[command(about = "Deploy declared verifier contract")]
-    Deploy {
-        /// Class hash of the declared contract
-        #[arg(long)]
-        class_hash: Option<String>,
-    },
-
-    /// Verify proof on-chain
-    #[command(about = "Verify proof on Starknet using deployed verifier")]
-    VerifyOnchain {
-        /// Address of deployed verifier contract
-        #[arg(short = 'a', long)]
-        address: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum EvmCommands {
-    /// Generate Solidity verifier contract and Foundry project
-    #[command(about = "Generate Solidity verifier contract with complete Foundry project setup")]
-    Gen,
-
-    /// Generate Keccak oracle proof
-    #[command(about = "Generate proof using bb with Keccak oracle hash")]
-    Prove,
-
-    /// Verify Keccak oracle proof
-    #[command(about = "Verify proof generated with Keccak oracle hash")]
-    Verify,
-
-    /// Deploy verifier contract to EVM network
-    #[command(about = "Deploy verifier contract using Foundry")]
-    Deploy {
-        /// Network to deploy to (mainnet or sepolia)
-        #[arg(long, default_value = "sepolia")]
-        network: String,
-    },
-
-    /// Generate calldata for proof verification
-    #[command(about = "Generate calldata for proof verification using cast")]
-    Calldata,
-
-    /// Verify proof on-chain
-    #[command(about = "Verify proof on EVM network using deployed verifier")]
-    VerifyOnchain,
-}
-
-#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum Backend {
-    /// Barretenberg backend (EVM/Solidity)
-    Bb,
-    /// Starknet backend (Cairo)
-    Starknet,
-    /// All backends
-    All,
-}
+pub use cli::Cli;
+pub use config::Config;
 
 pub fn run() -> Result<()> {
-    // Install color-eyre for pretty error reporting
     color_eyre::install()?;
-
-    // Load .env file if present (for EVM environment variables)
-    dotenv::dotenv().ok(); // .ok() means don't fail if .env doesn't exist
+    dotenv::dotenv().ok();
 
     let cli = Cli::parse();
-
-    // Initialize logging based on verbosity
     setup_logging(cli.verbose, cli.quiet)?;
 
     if cli.verbose {
@@ -188,122 +26,8 @@ pub fn run() -> Result<()> {
         }
     }
 
-    // Route to appropriate command handler
-    match cli.command {
-        Commands::Check => {
-            if !cli.quiet {
-                print_banner("check");
-            }
-            handle_check(&cli)?;
-        }
-        Commands::Build => {
-            if !cli.quiet {
-                print_banner("build");
-            }
-            handle_build(&cli)?;
-        }
-
-        Commands::Clean { ref backend } => {
-            if !cli.quiet {
-                print_banner("clean");
-            }
-            handle_clean(&cli, (*backend).unwrap_or(Backend::All))?;
-        }
-        Commands::Rebuild { ref backend } => {
-            if !cli.quiet {
-                print_banner("rebuild");
-            }
-            handle_rebuild(&cli, (*backend).unwrap_or(Backend::All))?;
-        }
-        Commands::Cairo { ref command } => match command {
-            CairoCommands::Gen => {
-                if !cli.quiet {
-                    print_banner("cairo gen");
-                }
-                handle_cairo_gen(&cli)?;
-            }
-            CairoCommands::Prove => {
-                if !cli.quiet {
-                    print_banner("cairo prove");
-                }
-                handle_cairo_prove(&cli)?;
-            }
-            CairoCommands::Verify => {
-                if !cli.quiet {
-                    print_banner("cairo verify");
-                }
-                handle_cairo_verify(&cli)?;
-            }
-            CairoCommands::Calldata => {
-                if !cli.quiet {
-                    print_banner("cairo calldata");
-                }
-                handle_cairo_calldata(&cli)?;
-            }
-            CairoCommands::Declare { network } => {
-                if !cli.quiet {
-                    print_banner("cairo declare");
-                }
-                handle_cairo_declare(&cli, network)?;
-            }
-            CairoCommands::Deploy { class_hash } => {
-                if !cli.quiet {
-                    print_banner("cairo deploy");
-                }
-                handle_cairo_deploy(&cli, class_hash.as_deref())?;
-            }
-            CairoCommands::VerifyOnchain { address } => {
-                if !cli.quiet {
-                    print_banner("cairo verify-onchain");
-                }
-                handle_cairo_verify_onchain(&cli, address.as_deref())?;
-            }
-        },
-        Commands::Evm { ref command } => match command {
-            EvmCommands::Gen => {
-                if !cli.quiet {
-                    print_banner("evm gen");
-                }
-                handle_evm_gen(&cli)?;
-            }
-            EvmCommands::Prove => {
-                if !cli.quiet {
-                    print_banner("evm prove");
-                }
-                handle_evm_prove(&cli)?;
-            }
-            EvmCommands::Verify => {
-                if !cli.quiet {
-                    print_banner("evm verify");
-                }
-                handle_evm_verify(&cli)?;
-            }
-            EvmCommands::Deploy { network } => {
-                if !cli.quiet {
-                    print_banner("evm deploy");
-                }
-                handle_evm_deploy(&cli, network)?;
-            }
-            EvmCommands::Calldata => {
-                if !cli.quiet {
-                    print_banner("evm calldata");
-                }
-                handle_evm_calldata(&cli)?;
-            }
-            EvmCommands::VerifyOnchain => {
-                if !cli.quiet {
-                    print_banner("evm verify-onchain");
-                }
-                handle_evm_verify_onchain(&cli)?;
-            }
-        },
-        Commands::Doctor => {
-            if !cli.quiet {
-                print_banner("doctor");
-            }
-            handle_doctor(&cli)?;
-        }
-    }
+    let cfg = Config::from(&cli);
+    dispatch(&cli, &cfg)?;
 
     if cli.verbose {
         info!("✨ bargo completed successfully");
@@ -312,11 +36,130 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
+fn dispatch(cli: &Cli, cfg: &Config) -> Result<()> {
+    use cli::{Backend, CairoCommands, Commands, EvmCommands};
+    use util::print_banner;
+
+    match &cli.command {
+        Commands::Check => {
+            if !cfg.quiet {
+                print_banner("check");
+            }
+            commands::check::run(cfg)
+        }
+        Commands::Build => {
+            if !cfg.quiet {
+                print_banner("build");
+            }
+            commands::build::run(cfg)
+        }
+        Commands::Clean { backend } => {
+            if !cfg.quiet {
+                print_banner("clean");
+            }
+            commands::clean::run(cfg, backend.unwrap_or(Backend::All))
+        }
+        Commands::Rebuild { backend } => {
+            if !cfg.quiet {
+                print_banner("rebuild");
+            }
+            commands::rebuild::run(cfg, backend.unwrap_or(Backend::All))
+        }
+        Commands::Cairo { command } => match command {
+            CairoCommands::Gen => {
+                if !cfg.quiet {
+                    print_banner("cairo gen");
+                }
+                commands::cairo::run_gen(cfg)
+            }
+            CairoCommands::Prove => {
+                if !cfg.quiet {
+                    print_banner("cairo prove");
+                }
+                commands::cairo::run_prove(cfg)
+            }
+            CairoCommands::Verify => {
+                if !cfg.quiet {
+                    print_banner("cairo verify");
+                }
+                commands::cairo::run_verify(cfg)
+            }
+            CairoCommands::Calldata => {
+                if !cfg.quiet {
+                    print_banner("cairo calldata");
+                }
+                commands::cairo::run_calldata(cfg)
+            }
+            CairoCommands::Declare { network } => {
+                if !cfg.quiet {
+                    print_banner("cairo declare");
+                }
+                commands::cairo::run_declare(cfg, network)
+            }
+            CairoCommands::Deploy { class_hash } => {
+                if !cfg.quiet {
+                    print_banner("cairo deploy");
+                }
+                commands::cairo::run_deploy(cfg, class_hash.as_deref())
+            }
+            CairoCommands::VerifyOnchain { address } => {
+                if !cfg.quiet {
+                    print_banner("cairo verify-onchain");
+                }
+                commands::cairo::run_verify_onchain(cfg, address.as_deref())
+            }
+        },
+        Commands::Evm { command } => match command {
+            EvmCommands::Gen => {
+                if !cfg.quiet {
+                    print_banner("evm gen");
+                }
+                commands::evm::run_gen(cfg)
+            }
+            EvmCommands::Prove => {
+                if !cfg.quiet {
+                    print_banner("evm prove");
+                }
+                commands::evm::run_prove(cfg)
+            }
+            EvmCommands::Verify => {
+                if !cfg.quiet {
+                    print_banner("evm verify");
+                }
+                commands::evm::run_verify(cfg)
+            }
+            EvmCommands::Deploy { network } => {
+                if !cfg.quiet {
+                    print_banner("evm deploy");
+                }
+                commands::evm::run_deploy(cfg, network)
+            }
+            EvmCommands::Calldata => {
+                if !cfg.quiet {
+                    print_banner("evm calldata");
+                }
+                commands::evm::run_calldata(cfg)
+            }
+            EvmCommands::VerifyOnchain => {
+                if !cfg.quiet {
+                    print_banner("evm verify-onchain");
+                }
+                commands::evm::run_verify_onchain(cfg)
+            }
+        },
+        Commands::Doctor => {
+            if !cfg.quiet {
+                print_banner("doctor");
+            }
+            commands::doctor::run(cfg)
+        }
+    }
+}
+
 fn setup_logging(verbose: bool, quiet: bool) -> Result<()> {
-    use tracing_subscriber::{EnvFilter, fmt};
+    use tracing_subscriber::{fmt, EnvFilter};
 
     if quiet {
-        // Only show errors
         let subscriber = fmt()
             .with_max_level(tracing::Level::ERROR)
             .with_target(false)
@@ -324,18 +167,14 @@ fn setup_logging(verbose: bool, quiet: bool) -> Result<()> {
             .finish();
         tracing::subscriber::set_global_default(subscriber)?;
     } else if verbose {
-        // Show info and above, plus set RUST_LOG environment
-        unsafe {
-            std::env::set_var("RUST_LOG", "info");
-        }
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
         let subscriber = fmt()
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(filter)
             .with_target(false)
             .with_level(true)
             .finish();
         tracing::subscriber::set_global_default(subscriber)?;
     } else {
-        // Default: only show warnings and errors
         let subscriber = fmt()
             .with_max_level(tracing::Level::WARN)
             .with_target(false)
@@ -345,346 +184,4 @@ fn setup_logging(verbose: bool, quiet: bool) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn handle_check(cli: &Cli) -> Result<()> {
-    let args = build_nargo_args(cli, &[])?;
-
-    if cli.verbose {
-        info!("Running: nargo check {}", args.join(" "));
-    }
-
-    if cli.dry_run {
-        println!("Would run: nargo check {}", args.join(" "));
-        return Ok(());
-    }
-
-    backends::nargo::run(&["check"])
-}
-
-fn handle_build(cli: &Cli) -> Result<()> {
-    commands::build::run(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_prove(cli: &Cli) -> Result<()> {
-    commands::cairo::run_prove(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_verify(cli: &Cli) -> Result<()> {
-    commands::cairo::run_verify(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_evm_prove(cli: &Cli) -> Result<()> {
-    commands::evm::run_prove(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_evm_verify(cli: &Cli) -> Result<()> {
-    commands::evm::run_verify(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_clean(cli: &Cli, backend: Backend) -> Result<()> {
-    if cli.verbose {
-        info!("Cleaning artifacts for backend: {:?}", backend);
-    }
-
-    match backend {
-        Backend::All => {
-            if cli.dry_run {
-                println!("Would run: rm -rf target/");
-                return Ok(());
-            }
-
-            if std::path::Path::new("target").exists() {
-                std::fs::remove_dir_all("target")?;
-                if !cli.quiet {
-                    println!("{}", success("Removed target/"));
-                }
-            } else if !cli.quiet {
-                println!("{}", info("target/ already clean"));
-            }
-        }
-        Backend::Bb => {
-            if cli.dry_run {
-                println!("Would run: rm -rf target/bb/");
-                return Ok(());
-            }
-
-            if std::path::Path::new("target/bb").exists() {
-                std::fs::remove_dir_all("target/bb")?;
-                if !cli.quiet {
-                    println!("{}", success("Removed target/bb/"));
-                }
-            } else if !cli.quiet {
-                println!("{}", info("target/bb/ already clean"));
-            }
-        }
-        Backend::Starknet => {
-            if cli.dry_run {
-                println!("Would run: rm -rf target/starknet/");
-                return Ok(());
-            }
-
-            if std::path::Path::new("target/starknet").exists() {
-                std::fs::remove_dir_all("target/starknet")?;
-                if !cli.quiet {
-                    println!("{}", success("Removed target/starknet/"));
-                }
-            } else if !cli.quiet {
-                println!("{}", info("target/starknet/ already clean"));
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn build_nargo_args(cli: &Cli, base_args: &[&str]) -> Result<Vec<String>> {
-    let mut args = base_args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-
-    // Add package-specific args if needed
-    if let Some(pkg) = &cli.pkg {
-        args.push("--package".to_string());
-        args.push(pkg.clone());
-    }
-
-    Ok(args)
-}
-
-fn handle_rebuild(cli: &Cli, backend: Backend) -> Result<()> {
-    let mut summary = OperationSummary::new();
-
-    // Step 1: Clean
-    if cli.verbose {
-        info!("Step 1/2: Cleaning artifacts for backend: {:?}", backend);
-    }
-
-    if !cli.quiet {
-        println!("🧹 Cleaning build artifacts...");
-    }
-
-    handle_clean(cli, backend)?;
-    if backend != Backend::Starknet {
-        summary.add_operation("Build artifacts cleaned");
-    }
-
-    // Step 2: Build
-    if cli.verbose {
-        info!("Step 2/2: Building from scratch");
-    }
-
-    if !cli.quiet {
-        println!("\n🔨 Building circuit...");
-    }
-
-    let pkg_name = get_package_name(cli)?;
-    let args = build_nargo_args(cli, &[])?;
-
-    if cli.verbose {
-        info!("Running: nargo execute {}", args.join(" "));
-    }
-
-    if cli.dry_run {
-        println!("Would run: nargo execute {}", args.join(" "));
-        return Ok(());
-    }
-
-    let timer = Timer::start();
-    let result = backends::nargo::run(&["execute"]);
-
-    match result {
-        Ok(()) => {
-            // Organize build artifacts into flavour-specific directories
-            util::organize_build_artifacts(&pkg_name, Flavour::Bb)?;
-
-            if !cli.quiet {
-                let bytecode_path = util::get_bytecode_path(&pkg_name, Flavour::Bb);
-                let witness_path = util::get_witness_path(&pkg_name, Flavour::Bb);
-
-                println!(
-                    "{}",
-                    success(&format_operation_result(
-                        "Bytecode generated",
-                        &bytecode_path,
-                        &timer
-                    ))
-                );
-
-                // Create a new timer for witness (they're generated together but we show separate timing)
-                let witness_timer = Timer::start();
-                println!(
-                    "{}",
-                    success(&format_operation_result(
-                        "Witness generated",
-                        &witness_path,
-                        &witness_timer
-                    ))
-                );
-
-                summary.add_operation(&format!("Circuit rebuilt for {}", path(&pkg_name)));
-                summary.add_operation(&format!(
-                    "Bytecode generated ({})",
-                    util::format_file_size(&bytecode_path)
-                ));
-                summary.add_operation(&format!(
-                    "Witness generated ({})",
-                    util::format_file_size(&witness_path)
-                ));
-                summary.print();
-            }
-            Ok(())
-        }
-        Err(e) => Err(enhance_error_with_suggestions(e)),
-    }
-}
-
-fn handle_cairo_gen(cli: &Cli) -> Result<()> {
-    commands::cairo::run_gen(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_calldata(cli: &Cli) -> Result<()> {
-    commands::cairo::run_calldata(cli).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_declare(cli: &Cli, network: &str) -> Result<()> {
-    commands::cairo::run_declare(cli, network).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_deploy(cli: &Cli, class_hash: Option<&str>) -> Result<()> {
-    commands::cairo::run_deploy(cli, class_hash).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_cairo_verify_onchain(cli: &Cli, address: Option<&str>) -> Result<()> {
-    commands::cairo::run_verify_onchain(cli, address).map_err(enhance_error_with_suggestions)
-}
-
-fn handle_doctor(cli: &Cli) -> Result<()> {
-    if !cli.quiet {
-        println!("🔍 Checking system dependencies...\n");
-    }
-
-    let mut all_good = true;
-
-    // Check nargo
-    match which::which("nargo") {
-        Ok(path) => {
-            if !cli.quiet {
-                println!("✅ nargo: {}", path.display());
-            }
-        }
-        Err(_) => {
-            if !cli.quiet {
-                println!("❌ nargo: not found");
-                println!(
-                    "   Install from: https://noir-lang.org/docs/getting_started/installation/"
-                );
-            }
-            all_good = false;
-        }
-    }
-
-    // Check bb
-    match which::which("bb") {
-        Ok(path) => {
-            if !cli.quiet {
-                println!("✅ bb: {}", path.display());
-            }
-        }
-        Err(_) => {
-            if !cli.quiet {
-                println!("❌ bb: not found");
-                println!("   Install from: https://github.com/AztecProtocol/aztec-packages");
-            }
-            all_good = false;
-        }
-    }
-
-    // Check garaga (optional for Cairo features)
-    match which::which("garaga") {
-        Ok(path) => {
-            if !cli.quiet {
-                println!("✅ garaga: {}", path.display());
-            }
-        }
-        Err(_) => {
-            if !cli.quiet {
-                println!("⚠️  garaga: not found (optional - needed for Cairo features)");
-                println!("   Install with: pipx install garaga");
-                println!("   Requires Python 3.10+");
-            }
-        }
-    }
-
-    // Check forge (optional for EVM features)
-    match which::which("forge") {
-        Ok(path) => {
-            if !cli.quiet {
-                println!("✅ forge: {}", path.display());
-            }
-        }
-        Err(_) => {
-            if !cli.quiet {
-                println!("⚠️  forge: not found (optional - needed for EVM features)");
-                println!("   Install with: curl -L https://foundry.paradigm.xyz | bash");
-                println!("   Then run: foundryup");
-            }
-        }
-    }
-
-    // Check cast (optional for EVM features)
-    match which::which("cast") {
-        Ok(path) => {
-            if !cli.quiet {
-                println!("✅ cast: {}", path.display());
-            }
-        }
-        Err(_) => {
-            if !cli.quiet {
-                println!("⚠️  cast: not found (optional - needed for EVM features)");
-                println!("   Install with: curl -L https://foundry.paradigm.xyz | bash");
-                println!("   Then run: foundryup");
-            }
-        }
-    }
-
-    if !cli.quiet {
-        println!();
-        if all_good {
-            println!("🎉 All required dependencies are available!");
-            println!("   You can use all bargo features.");
-        } else {
-            println!("🚨 Some required dependencies are missing.");
-            println!("   Core features require: nargo + bb");
-            println!("   EVM deployment features also require: forge + cast");
-            println!("   Cairo features also require: garaga");
-        }
-    }
-
-    if !all_good {
-        std::process::exit(1);
-    }
-
-    Ok(())
-}
-
-fn get_package_name(cli: &Cli) -> Result<String> {
-    util::get_package_name(cli.pkg.as_ref()).map_err(enhance_error_with_suggestions)
-}
-
-/// Handle `evm gen` command - Generate Solidity verifier contract and Foundry project
-fn handle_evm_gen(cli: &Cli) -> Result<()> {
-    commands::evm::run_gen(cli).map_err(enhance_error_with_suggestions)
-}
-/// Handle `evm deploy` command - Deploy verifier contract to EVM network
-fn handle_evm_deploy(cli: &Cli, network: &str) -> Result<()> {
-    commands::evm::run_deploy(cli, network).map_err(enhance_error_with_suggestions)
-}
-
-/// Handle `evm calldata` command - Generate calldata for proof verification
-fn handle_evm_calldata(cli: &Cli) -> Result<()> {
-    commands::evm::run_calldata(cli).map_err(enhance_error_with_suggestions)
-}
-
-/// Handle `evm verify-onchain` command - Verify proof on EVM network
-fn handle_evm_verify_onchain(cli: &Cli) -> Result<()> {
-    commands::evm::run_verify_onchain(cli).map_err(enhance_error_with_suggestions)
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1,0 +1,21 @@
+use assert_cmd::Command;
+
+#[test]
+fn cli_still_builds_and_parses() {
+    Command::cargo_bin("bargo")
+        .unwrap()
+        .args(["--dry-run", "build"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn pkg_flag_is_propagated() {
+    use predicates::str::contains;
+
+    Command::cargo_bin("bargo")
+        .unwrap()
+        .args(["--dry-run", "--pkg", "my_pkg", "build"])
+        .assert()
+        .stdout(contains("--package my_pkg"));
+}


### PR DESCRIPTION
## Summary
- move clap structs to new `cli.rs`
- introduce `Config` for global flags
- split command handlers into modules under `commands/`
- update workflows to use `Config`
- slim down `lib.rs` to command dispatch layer
- add shared helper and smoke test
- propagate `--pkg` flag through `build_nargo_args`
- clean up logging setup

## Testing
- `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: 'cargo-clippy' not installed)*
- `cargo test`
- `cargo run --quiet -- check` *(fails: cannot find a Nargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_685ba97fb2a083298f365c67e64f81b1